### PR TITLE
Setting coverage threshold to 50% for C# tempalted test.

### DIFF
--- a/tests_integration/test_all.sh
+++ b/tests_integration/test_all.sh
@@ -79,6 +79,7 @@ sh tests_integration/test_with_docker.sh \
   --code-coverage-report-path "CalculatorApi.Tests/TestResults/coverage.cobertura.xml" \
   --test-command "dotnet test --collect:'XPlat Code Coverage' CalculatorApi.Tests/ && find . -name 'coverage.cobertura.xml' -exec mv {} CalculatorApi.Tests/TestResults/coverage.cobertura.xml \;" \
   --coverage-type "cobertura" \
+  --desired-coverage "50" \
   --model $MODEL \
   $log_db_arg
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Set code coverage threshold to 50% for C# tests.

- Updated integration test script to include `--desired-coverage` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_all.sh</strong><dd><code>Add code coverage threshold parameter to test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_integration/test_all.sh

<li>Added <code>--desired-coverage</code> parameter with a value of 50.<br> <li> Updated integration test script for C# tests.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/256/files#diff-65b6da080079e8f0585416d7e71797238296436ccac70a59aa5695b2a11a9d15">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information