### PR TITLE
Updating python call to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile
-SITE_PACKAGES=$(shell python -c "import wandb, os; print(os.path.dirname(wandb.__file__))")
+SITE_PACKAGES=$(shell python3 -c "import wandb, os; print(os.path.dirname(wandb.__file__))")
 TOML_FILES=$(shell find cover_agent/settings -name "*.toml" | sed 's/.*/-\-add-data "&:."/' | tr '\n' ' ')
 
 .PHONY: test build installer


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the Makefile to use `python3` instead of `python`.

- Ensures compatibility with environments where `python3` is explicitly required.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update `python` command to `python3` in Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Changed the <code>python</code> command to <code>python3</code> in the <code>SITE_PACKAGES</code> variable.<br> <li> Ensures compatibility with systems where <code>python3</code> is the default Python <br>version.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/258/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information