### PR TITLE
Removing bad reference to self.last_coverage_percentages 

### DIFF
--- a/cover_agent/UnitTestValidator.py
+++ b/cover_agent/UnitTestValidator.py
@@ -449,7 +449,6 @@ class UnitTestValidator:
                     if exit_code != 0:
                         break
                 
-
                 # Step 3: Check for pass/fail from the Runner object
                 if exit_code != 0:
                     # Test failed, roll back the test file to its original content
@@ -571,13 +570,13 @@ class UnitTestValidator:
                     old_v: CoverageData = self.current_coverage_report.file_coverage[key]
                     if new_v.coverage > old_v.coverage and key == self.source_file_path.split("/")[-1]:
                         self.logger.info(
-                            f"Coverage for provided source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(new_v.coverage * 100, 2)}"
+                            f"Coverage for provided source file: {key} increased to {round(new_v.coverage * 100, 2)}"
                         )
                     elif new_v.coverage > old_v.coverage:
                         self.logger.info(
-                            f"Coverage for non-source file: {key} increased from {round(self.last_coverage_percentages[key] * 100, 2)} to {round(new_v.coverage * 100, 2)}"
+                            f"Coverage for non-source file: {key} increased to {round(new_v.coverage * 100, 2)}"
                         )
-
+                
                 self.logger.info(
                     f"Test passed and coverage increased. Current coverage: {round(new_coverage_report.total_coverage * 100, 2)}%"
                 )


### PR DESCRIPTION
### **User description**
This is causing logs that look like that are causing errors when there really aren't any errors. `self.last_coverage_percentages ` is never updated, so there is no `key` to be referenced. 

Before: 
```
2025-01-07 22:14:08,946 - cover_agent.UnitTestValidator - INFO - Running test with the following command: "pytest --cov=. --cov-report=xml --cov-report=term"
2025-01-07 22:14:10,013 - cover_agent.UnitTestValidator - INFO - coverage: Percentage 71.93%
2025-01-07 22:14:10,013 - cover_agent.UnitTestValidator - ERROR - Error validating test: 'app.py'
```

After:
```
2025-01-07 22:14:55,079 - cover_agent.UnitTestValidator - INFO - Running test with the following command: "pytest --cov=. --cov-report=xml --cov-report=term"
2025-01-07 22:14:56,156 - cover_agent.UnitTestValidator - INFO - coverage: Percentage 82.61%
2025-01-07 22:14:56,156 - cover_agent.UnitTestValidator - INFO - Coverage for provided source file: app.py increased to 72.73
2025-01-07 22:14:56,156 - cover_agent.UnitTestValidator - INFO - Test passed and coverage increased. Current coverage: 82.61%
```


___

### **PR Type**
Bug fix


___

### **Description**
- Removed invalid reference to `self.last_coverage_percentages`.

- Fixed misleading error logs during test validation.

- Improved logging for coverage changes in source and non-source files.

- Ensured accurate reporting of test coverage increases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UnitTestValidator.py</strong><dd><code>Fix invalid reference and improve coverage logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/UnitTestValidator.py

<li>Removed references to <code>self.last_coverage_percentages</code> to fix errors.<br> <li> Updated logging messages for coverage increases.<br> <li> Improved clarity and accuracy of coverage-related logs.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/262/files#diff-8e82655eb4312e27ba8b876368f619bb3fe73990d9c0ef379959a2b210141252">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information