### PR TITLE
Support api_base in full_repo

### DIFF
--- a/cover_agent/main_full_repo.py
+++ b/cover_agent/main_full_repo.py
@@ -23,7 +23,7 @@ async def run():
     async with context_helper.start_server():
         print("LSP server initialized.")
 
-        ai_caller = AICaller(model=args.model)
+        ai_caller = AICaller(model=args.model, api_base=args.api_base)
 
         # main loop for analyzing test files
         for test_file in test_files:


### PR DESCRIPTION
### **User description**
Hi,

I noticed the api_base wasn't being passed through in the full repo scan. Added it.


___

### **PR Type**
Bug fix


___

### **Description**
- Added support for `api_base` in `AICaller` initialization.

- Ensured `api_base` is passed during full repository scans.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main_full_repo.py</strong><dd><code>Pass `api_base` to `AICaller` initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cover_agent/main_full_repo.py

<li>Modified <code>AICaller</code> initialization to include <code>api_base</code>.<br> <li> Ensured <code>api_base</code> is passed from <code>args</code> to <code>AICaller</code>.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/268/files#diff-d3343a49fd7e2fdb3276857162c04eb4b8e6a85ff901fdb1150a3d96398b9869">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>