### PR TITLE
Add wandb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pyvenv.cfg
 pip-log.txt
 pip-delete-this-directory.txt
 *.spec
+
+# Other
+wandb/


### PR DESCRIPTION
### **PR Type**
other


___

### **Description**
- Added `wandb` to the `.gitignore` file to prevent unnecessary files from being tracked in the repository.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>