### PR TITLE
Fix: correctly pass api_base and add --max-run-time CLI argument in main_full_repo

### DIFF
--- a/cover_agent/main_full_repo.py
+++ b/cover_agent/main_full_repo.py
@@ -28,7 +28,7 @@ async def run():
     async with context_helper.start_server():
         print("LSP server initialized.")
 
-        ai_caller = AICaller(model=args.model)
+        ai_caller = AICaller(model=args.model,api_base=args.api_base, max_tokens=8192)
 
         # main loop for analyzing test files
         for test_file in test_files:

--- a/cover_agent/utils.py
+++ b/cover_agent/utils.py
@@ -331,6 +331,12 @@ def parse_args_full_repo():
         type=str,
         default="main",
     )
+    parser.add_argument(
+        "--max-run-time",
+        type=int,
+        default=30,
+        help="Maximum time (in seconds) allowed for test execution. Overrides the value in configuration.toml if provided. Defaults to 30 seconds.",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
### What this PR does

This PR fixes two issues encountered when running the `main_full_repo` entry point:

1. **`api_base` not passed to `AICaller`:**  
   The CLI argument `--api_base` was accepted but never passed into `AICaller`, making it ineffective.  
   ✅ Fixed by modifying the initialization of `AICaller` to include `api_base`.

3. **Missing `--max-run-time` argument:**  
   The CLI argument parser `parse_args_full_repo` did not include `--max-run-time`, which led to runtime errors like:  
'Namespace' object has no attribute 'max_run_time'
   ✅ Added the missing argument to `argparse`.

Optionally, I also added `max_tokens` manually to the `AICaller` init call with a default value (`8192`) to avoid instantiation errors.

---

### Suggested labels:
`bug`, `CLI`, `enhancement`

Let me know if any changes are needed — happy to update!