### PR TITLE
Remove args Namespace from CoverAgent Constructor #299

### DIFF
--- a/cover_agent/CoverAgent.py
+++ b/cover_agent/CoverAgent.py
@@ -87,7 +87,7 @@ class CoverAgent:
 
         # Update test command if successfully modified
         if new_command_line:
-            self.test_command_original = test_command
+            self.config.test_command_original = test_command
             self.config.test_command = new_command_line
             print(
                 f"Converting test command: `{test_command}`\n to run only a single test: `{new_command_line}`"

--- a/cover_agent/main.py
+++ b/cover_agent/main.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from cover_agent.CoverAgent import CoverAgent
+from cover_agent.settings.config_schema import CoverAgentConfig
 from cover_agent.version import __version__
 
 
@@ -141,7 +142,8 @@ def parse_args():
 
 def main():
     args = parse_args()
-    agent = CoverAgent(args)
+    config = CoverAgentConfig.from_args_with_defaults(args)
+    agent = CoverAgent(config)
     agent.run()
 
 

--- a/cover_agent/settings/config_schema.py
+++ b/cover_agent/settings/config_schema.py
@@ -50,6 +50,8 @@ class CoverAgentConfig:
     
     # Logging settings
     log_db_path: str
+
+    test_command_original: Optional[str] = None
     
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> 'CoverAgentConfig':

--- a/cover_agent/settings/config_schema.py
+++ b/cover_agent/settings/config_schema.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass
+from typing import List, Optional
+import argparse
+from cover_agent.settings.config_loader import get_settings
+
+
+@dataclass
+class CoverAgentConfig:
+    """Configuration dataclass for Cover Agent settings"""
+    
+    # Required file paths
+    source_file_path: str
+    test_file_path: str
+    code_coverage_report_path: str
+    
+    # Test execution settings
+    test_command: str
+    test_command_dir: str
+    
+    # Project settings
+    project_root: str
+    test_file_output_path: str
+    
+    # Coverage settings
+    included_files: Optional[List[str]]
+    coverage_type: str
+    report_filepath: str
+    desired_coverage: int
+    
+    # Execution limits
+    max_iterations: int
+    max_run_time: int
+    
+    # LLM model configuration
+    model: str
+    api_base: str
+    additional_instructions: str
+    
+    # Test execution options
+    strict_coverage: bool
+    run_tests_multiple_times: int
+    run_each_test_separately: bool
+    
+    # Coverage evaluation modes (mutually exclusive)
+    use_report_coverage_feature_flag: bool
+    diff_coverage: bool
+    
+    # Git branch for diff coverage
+    branch: str
+    
+    # Logging settings
+    log_db_path: str
+    
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> 'CoverAgentConfig':
+        """
+        Create a CoverAgentConfig instance from command line arguments. No defaults are applied.
+        This method is used when all required parameters are provided via command line.
+        
+        Parameters:
+            args (argparse.Namespace): Command line arguments parsed from main.py
+            
+        Returns:
+            CoverAgentConfig: An initialized configuration object
+        """
+        return cls(
+            source_file_path=args.source_file_path,
+            test_file_path=args.test_file_path,
+            code_coverage_report_path=args.code_coverage_report_path,
+            test_command=args.test_command,
+            test_command_dir=args.test_command_dir,
+            project_root=args.project_root,
+            test_file_output_path=args.test_file_output_path,
+            included_files=args.included_files,
+            coverage_type=args.coverage_type,
+            report_filepath=args.report_filepath,
+            desired_coverage=args.desired_coverage,
+            max_iterations=args.max_iterations,
+            max_run_time=args.max_run_time,
+            model=args.model,
+            api_base=args.api_base,
+            additional_instructions=args.additional_instructions,
+            strict_coverage=args.strict_coverage,
+            run_tests_multiple_times=args.run_tests_multiple_times,
+            run_each_test_separately=args.run_each_test_separately,
+            use_report_coverage_feature_flag=args.use_report_coverage_feature_flag,
+            diff_coverage=args.diff_coverage,
+            branch=args.branch,
+            log_db_path=args.log_db_path
+        )
+    
+    @classmethod
+    def from_args_with_defaults(cls, args: argparse.Namespace) -> 'CoverAgentConfig':
+        """
+        Create a CoverAgentConfig instance using TOML defaults for missing values.
+        
+        This method prioritizes command-line arguments when available, but falls
+        back to configuration.toml defaults for any missing values.
+        
+        Parameters:
+            args (argparse.Namespace): Command line arguments parsed from main.py
+            
+        Returns:
+            CoverAgentConfig: A configuration object with values from both sources
+        """
+        # First load defaults from TOML
+        toml_config = get_settings().get('default')
+        
+        # Create a dictionary from the args Namespace
+        args_dict = vars(args)
+        
+        # Create a dictionary from the TOML defaults
+        toml_dict = {
+            'source_file_path': toml_config.source_file_path,
+            'test_file_path': toml_config.test_file_path,
+            'code_coverage_report_path': toml_config.code_coverage_report_path,
+            'test_command': toml_config.test_command,
+            'test_command_dir': toml_config.test_command_dir,
+            'project_root': toml_config.project_root,
+            'test_file_output_path': toml_config.test_file_output_path,
+            'included_files': toml_config.included_files,
+            'coverage_type': toml_config.coverage_type,
+            'report_filepath': toml_config.report_filepath,
+            'desired_coverage': toml_config.desired_coverage,
+            'max_iterations': toml_config.max_iterations,
+            'max_run_time': toml_config.max_run_time,
+            'model': toml_config.model,
+            'api_base': toml_config.api_base,
+            'additional_instructions': toml_config.additional_instructions,
+            'strict_coverage': toml_config.strict_coverage,
+            'run_tests_multiple_times': toml_config.run_tests_multiple_times,
+            'run_each_test_separately': toml_config.run_each_test_separately,
+            'use_report_coverage_feature_flag': toml_config.use_report_coverage_feature_flag,
+            'diff_coverage': toml_config.diff_coverage,
+            'branch': toml_config.branch,
+            'log_db_path': toml_config.log_db_path
+        }
+        
+        # Merge the two dictionaries, prioritizing args values when they exist
+        merged_dict = toml_dict.copy()
+        for k, v in args_dict.items():
+            if v is not None and hasattr(args, k):
+                merged_dict[k] = v
+        
+        # Create config from the merged dictionary
+        return cls(**merged_dict)

--- a/cover_agent/settings/configuration.toml
+++ b/cover_agent/settings/configuration.toml
@@ -1,6 +1,50 @@
 [include_files]
-limit_tokens=true
-max_tokens=20000
+limit_tokens = true
+max_tokens = 20000
 
 [tests]
-max_allowed_runtime_seconds=30
+max_allowed_runtime_seconds = 30
+
+[default]
+# Required file paths - no defaults, these must be provided
+source_file_path = ""
+test_file_path = ""
+code_coverage_report_path = ""
+test_command = ""
+
+# Test execution settings
+test_command_dir = ""
+
+# Project settings
+project_root = ""
+test_file_output_path = ""
+
+# Coverage settings
+included_files = []
+coverage_type = "cobertura"
+report_filepath = "test_results.html"
+desired_coverage = 90
+
+# Execution limits
+max_iterations = 10
+max_run_time = 30
+
+# LLM model configuration
+model = "gpt-4o"
+api_base = "http://localhost:11434"
+additional_instructions = ""
+
+# Test execution options
+strict_coverage = false
+run_tests_multiple_times = 1
+run_each_test_separately = false
+
+# Coverage evaluation modes (mutually exclusive)
+use_report_coverage_feature_flag = false
+diff_coverage = false
+
+# Git branch for diff coverage
+branch = "main"
+
+# Logging settings
+log_db_path = "cover_agent_unit_test_runs.db"

--- a/tests/test_CoverAgent.py
+++ b/tests/test_CoverAgent.py
@@ -378,7 +378,7 @@ class TestCoverAgent:
 
             # Verify the test command was modified correctly
             #assert hasattr(args, "test_command_original")
-            assert agent.test_command_original == "pytest --cov=myapp --cov-report=xml"
+            assert agent.config.test_command_original == "pytest --cov=myapp --cov-report=xml"
             assert (
                 config.test_command
                 == "pytest tests/test_output.py --cov=myapp --cov-report=xml"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,419 @@
+import pytest
+import argparse
+from unittest.mock import patch, MagicMock
+from dataclasses import FrozenInstanceError
+
+from cover_agent.settings.config_schema import CoverAgentConfig
+
+
+class TestCoverAgentConfig:
+    """Test suite for CoverAgentConfig class."""
+
+    def test_init_with_required_args(self):
+        """Test basic initialization with required arguments."""
+        config = CoverAgentConfig(
+            source_file_path="source.py",
+            test_file_path="test.py",
+            code_coverage_report_path="coverage.xml",
+            test_command="pytest",
+            test_command_dir="/project",
+            project_root="/project",
+            test_file_output_path="test_output.py",
+            included_files=["file1.py", "file2.py"],
+            coverage_type="cobertura",
+            report_filepath="report.html",
+            desired_coverage=90,
+            max_iterations=10,
+            max_run_time=30,
+            model="gpt-4o",
+            api_base="http://localhost:11434",
+            additional_instructions="",
+            strict_coverage=False,
+            run_tests_multiple_times=1,
+            run_each_test_separately=False,
+            use_report_coverage_feature_flag=False,
+            diff_coverage=False,
+            branch="main",
+            log_db_path="test.db"
+        )
+
+        # Verify all attributes are correctly set
+        assert config.source_file_path == "source.py"
+        assert config.test_file_path == "test.py"
+        assert config.code_coverage_report_path == "coverage.xml"
+        assert config.test_command == "pytest"
+        assert config.test_command_dir == "/project"
+        assert config.project_root == "/project"
+        assert config.test_file_output_path == "test_output.py"
+        assert config.included_files == ["file1.py", "file2.py"]
+        assert config.coverage_type == "cobertura"
+        assert config.report_filepath == "report.html"
+        assert config.desired_coverage == 90
+        assert config.max_iterations == 10
+        assert config.max_run_time == 30
+        assert config.model == "gpt-4o"
+        assert config.api_base == "http://localhost:11434"
+        assert config.additional_instructions == ""
+        assert config.strict_coverage is False
+        assert config.run_tests_multiple_times == 1
+        assert config.run_each_test_separately is False
+        assert config.use_report_coverage_feature_flag is False
+        assert config.diff_coverage is False
+        assert config.branch == "main"
+        assert config.log_db_path == "test.db"
+
+    def test_init_with_missing_required_args(self):
+        """Test initialization fails when required arguments are missing."""
+        with pytest.raises(TypeError):
+            CoverAgentConfig(
+                # Missing required fields
+                source_file_path="source.py",
+                # Missing test_file_path and other required fields
+            )
+
+    def test_from_args(self):
+        """Test creating config from command-line arguments."""
+        args = argparse.Namespace(
+            source_file_path="source.py",
+            test_file_path="test.py",
+            code_coverage_report_path="coverage.xml",
+            test_command="pytest",
+            test_command_dir="/project",
+            project_root="/project",
+            test_file_output_path="test_output.py",
+            included_files=["file1.py", "file2.py"],
+            coverage_type="cobertura",
+            report_filepath="report.html",
+            desired_coverage=90,
+            max_iterations=10,
+            max_run_time=30,
+            model="gpt-4o",
+            api_base="http://localhost:11434",
+            additional_instructions="",
+            strict_coverage=False,
+            run_tests_multiple_times=1,
+            run_each_test_separately=False,
+            use_report_coverage_feature_flag=False,
+            diff_coverage=False,
+            branch="main",
+            log_db_path="test.db"
+        )
+
+        config = CoverAgentConfig.from_args(args)
+
+        # Verify all attributes match args
+        assert config.source_file_path == args.source_file_path
+        assert config.test_file_path == args.test_file_path
+        assert config.code_coverage_report_path == args.code_coverage_report_path
+        assert config.test_command == args.test_command
+        assert config.test_command_dir == args.test_command_dir
+        assert config.project_root == args.project_root
+        assert config.test_file_output_path == args.test_file_output_path
+        assert config.included_files == args.included_files
+        assert config.coverage_type == args.coverage_type
+        assert config.report_filepath == args.report_filepath
+        assert config.desired_coverage == args.desired_coverage
+        assert config.max_iterations == args.max_iterations
+        assert config.max_run_time == args.max_run_time
+        assert config.model == args.model
+        assert config.api_base == args.api_base
+        assert config.additional_instructions == args.additional_instructions
+        assert config.strict_coverage == args.strict_coverage
+        assert config.run_tests_multiple_times == args.run_tests_multiple_times
+        assert config.run_each_test_separately == args.run_each_test_separately
+        assert config.use_report_coverage_feature_flag == args.use_report_coverage_feature_flag
+        assert config.diff_coverage == args.diff_coverage
+        assert config.branch == args.branch
+        assert config.log_db_path == args.log_db_path
+
+    @patch("cover_agent.settings.config_schema.get_settings")
+    def test_from_args_with_defaults(self, mock_get_settings):
+        """Test creating config from args with TOML defaults for missing values."""
+        # Create mock settings
+        mock_settings = MagicMock()
+        mock_toml_config = MagicMock()
+        
+        # Define TOML default values
+        toml_defaults = {
+            'source_file_path': 'default_source.py',
+            'test_file_path': 'default_test.py',
+            'code_coverage_report_path': 'default_coverage.xml',
+            'test_command': 'default_pytest',
+            'test_command_dir': '/default_project',
+            'project_root': '/default_project',
+            'test_file_output_path': 'default_output.py',
+            'included_files': ['default1.py', 'default2.py'],
+            'coverage_type': 'default_cobertura',
+            'report_filepath': 'default_report.html',
+            'desired_coverage': 85,
+            'max_iterations': 5,
+            'max_run_time': 45,
+            'model': 'default-gpt-4o',
+            'api_base': 'http://default:11434',
+            'additional_instructions': 'default_instructions',
+            'strict_coverage': True,
+            'run_tests_multiple_times': 2,
+            'run_each_test_separately': True,
+            'use_report_coverage_feature_flag': True,
+            'diff_coverage': True,
+            'branch': 'default_main',
+            'log_db_path': 'default_test.db'
+        }
+        
+        # Set up the mocks to return our default values
+        for key, value in toml_defaults.items():
+            setattr(mock_toml_config, key, value)
+        
+        mock_settings.get.return_value = mock_toml_config
+        mock_get_settings.return_value = mock_settings
+        
+        # Create args with only some parameters specified (others will use defaults)
+        args = argparse.Namespace(
+            source_file_path="source.py",
+            test_file_path="test.py",
+            code_coverage_report_path=None,  # Will use default
+            test_command="pytest",
+            test_command_dir=None,  # Will use default
+            project_root=None,  # Will use default
+            test_file_output_path=None,  # Will use default
+            included_files=None,  # Will use default
+            coverage_type=None,  # Will use default
+            report_filepath=None,  # Will use default
+            desired_coverage=90,
+            max_iterations=None,  # Will use default
+            max_run_time=None,  # Will use default
+            model=None,  # Will use default
+            api_base=None,  # Will use default
+            additional_instructions=None,  # Will use default
+            strict_coverage=None,  # Will use default
+            run_tests_multiple_times=None,  # Will use default
+            run_each_test_separately=None,  # Will use default
+            use_report_coverage_feature_flag=None,  # Will use default
+            diff_coverage=None,  # Will use default
+            branch=None,  # Will use default
+            log_db_path=None,  # Will use default
+        )
+        
+        # Create config using from_args_with_defaults
+        config = CoverAgentConfig.from_args_with_defaults(args)
+        
+        # Verify overridden values from args
+        assert config.source_file_path == "source.py"
+        assert config.test_file_path == "test.py"
+        assert config.test_command == "pytest"
+        assert config.desired_coverage == 90
+        
+        # Verify default values from TOML
+        assert config.code_coverage_report_path == toml_defaults['code_coverage_report_path']
+        assert config.test_command_dir == toml_defaults['test_command_dir']
+        assert config.project_root == toml_defaults['project_root']
+        assert config.test_file_output_path == toml_defaults['test_file_output_path']
+        assert config.included_files == toml_defaults['included_files']
+        assert config.coverage_type == toml_defaults['coverage_type']
+        assert config.report_filepath == toml_defaults['report_filepath']
+        assert config.max_iterations == toml_defaults['max_iterations']
+        assert config.max_run_time == toml_defaults['max_run_time']
+        assert config.model == toml_defaults['model']
+        assert config.api_base == toml_defaults['api_base']
+        assert config.additional_instructions == toml_defaults['additional_instructions']
+        assert config.strict_coverage == toml_defaults['strict_coverage']
+        assert config.run_tests_multiple_times == toml_defaults['run_tests_multiple_times']
+        assert config.run_each_test_separately == toml_defaults['run_each_test_separately']
+        assert config.use_report_coverage_feature_flag == toml_defaults['use_report_coverage_feature_flag']
+        assert config.diff_coverage == toml_defaults['diff_coverage']
+        assert config.branch == toml_defaults['branch']
+        assert config.log_db_path == toml_defaults['log_db_path']
+
+    @patch("cover_agent.settings.config_schema.get_settings")
+    def test_args_override_defaults(self, mock_get_settings):
+        """Test that args properly override defaults when both are present."""
+        # Create mock settings
+        mock_settings = MagicMock()
+        mock_toml_config = MagicMock()
+        
+        # Define TOML default values (use a different set than the test_from_args_with_defaults test)
+        toml_defaults = {
+            'source_file_path': 'default_source.py',
+            'test_file_path': 'default_test.py',
+            'code_coverage_report_path': 'default_coverage.xml',
+            'test_command': 'default_pytest',
+            'test_command_dir': '/default_project',
+            'project_root': '/default_project',
+            'test_file_output_path': 'default_output.py',
+            'included_files': ['default1.py', 'default2.py'],
+            'coverage_type': 'default_cobertura',
+            'report_filepath': 'default_report.html',
+            'desired_coverage': 85,
+            'max_iterations': 5,
+            'max_run_time': 45,
+            'model': 'default-gpt-4o',
+            'api_base': 'http://default:11434',
+            'additional_instructions': 'default_instructions',
+            'strict_coverage': True,
+            'run_tests_multiple_times': 2,
+            'run_each_test_separately': True,
+            'use_report_coverage_feature_flag': True,
+            'diff_coverage': True,
+            'branch': 'default_main',
+            'log_db_path': 'default_test.db'
+        }
+        
+        # Set up the mocks to return our default values
+        for key, value in toml_defaults.items():
+            setattr(mock_toml_config, key, value)
+        
+        mock_settings.get.return_value = mock_toml_config
+        mock_get_settings.return_value = mock_settings
+        
+        # Create args with all parameters specified (all should override defaults)
+        args = argparse.Namespace(
+            source_file_path="override_source.py",
+            test_file_path="override_test.py",
+            code_coverage_report_path="override_coverage.xml",
+            test_command="override_pytest",
+            test_command_dir="/override_project",
+            project_root="/override_project",
+            test_file_output_path="override_output.py",
+            included_files=["override1.py", "override2.py"],
+            coverage_type="override_cobertura",
+            report_filepath="override_report.html",
+            desired_coverage=95,
+            max_iterations=15,
+            max_run_time=60,
+            model="override-gpt-4o",
+            api_base="http://override:11434",
+            additional_instructions="override_instructions",
+            strict_coverage=False,
+            run_tests_multiple_times=3,
+            run_each_test_separately=False,
+            use_report_coverage_feature_flag=False,
+            diff_coverage=False,
+            branch="override_main",
+            log_db_path="override_test.db",
+        )
+        
+        # Create config using from_args_with_defaults
+        config = CoverAgentConfig.from_args_with_defaults(args)
+        
+        # Verify all values come from args, not defaults
+        assert config.source_file_path == "override_source.py"
+        assert config.test_file_path == "override_test.py"
+        assert config.code_coverage_report_path == "override_coverage.xml"
+        assert config.test_command == "override_pytest"
+        assert config.test_command_dir == "/override_project"
+        assert config.project_root == "/override_project"
+        assert config.test_file_output_path == "override_output.py"
+        assert config.included_files == ["override1.py", "override2.py"]
+        assert config.coverage_type == "override_cobertura"
+        assert config.report_filepath == "override_report.html"
+        assert config.desired_coverage == 95
+        assert config.max_iterations == 15
+        assert config.max_run_time == 60
+        assert config.model == "override-gpt-4o"
+        assert config.api_base == "http://override:11434"
+        assert config.additional_instructions == "override_instructions"
+        assert config.strict_coverage is False
+        assert config.run_tests_multiple_times == 3
+        assert config.run_each_test_separately is False
+        assert config.use_report_coverage_feature_flag is False
+        assert config.diff_coverage is False
+        assert config.branch == "override_main"
+        assert config.log_db_path == "override_test.db"
+
+    @patch("cover_agent.settings.config_schema.get_settings")
+    def test_handle_none_values(self, mock_get_settings):
+        """Test how None values are handled in from_args_with_defaults."""
+        # Create mock settings
+        mock_settings = MagicMock()
+        mock_toml_config = MagicMock()
+        
+        # Define TOML default values
+        toml_defaults = {
+            'source_file_path': 'default_source.py',
+            'test_file_path': 'default_test.py',
+            'code_coverage_report_path': 'default_coverage.xml',
+            'test_command': 'default_pytest',
+            'test_command_dir': '/default_project',
+            'project_root': '/default_project',
+            'test_file_output_path': 'default_output.py',
+            'included_files': ['default1.py', 'default2.py'],
+            'coverage_type': 'default_cobertura',
+            'report_filepath': 'default_report.html',
+            'desired_coverage': 85,
+            'max_iterations': 5,
+            'max_run_time': 45,
+            'model': 'default-gpt-4o',
+            'api_base': 'http://default:11434',
+            'additional_instructions': 'default_instructions',
+            'strict_coverage': True,
+            'run_tests_multiple_times': 2,
+            'run_each_test_separately': True,
+            'use_report_coverage_feature_flag': True,
+            'diff_coverage': True,
+            'branch': 'default_main',
+            'log_db_path': 'default_test.db'
+        }
+        
+        # Set up the mocks to return our default values
+        for key, value in toml_defaults.items():
+            setattr(mock_toml_config, key, value)
+        
+        mock_settings.get.return_value = mock_toml_config
+        mock_get_settings.return_value = mock_settings
+        
+        # Create args with some None values
+        args = argparse.Namespace(
+            source_file_path=None,  # None value should use default
+            test_file_path="test.py",
+            code_coverage_report_path="coverage.xml",
+            test_command=None,  # None value should use default
+            test_command_dir="/project",
+            project_root="/project",
+            test_file_output_path="test_output.py",
+            included_files=None,  # None value should use default
+            coverage_type="cobertura",
+            report_filepath="report.html",
+            desired_coverage=90,
+            max_iterations=10,
+            max_run_time=30,
+            model="gpt-4o",
+            api_base="http://localhost:11434",
+            additional_instructions="",
+            strict_coverage=False,
+            run_tests_multiple_times=1,
+            run_each_test_separately=False,
+            use_report_coverage_feature_flag=False,
+            diff_coverage=False,
+            branch="main",
+            log_db_path="test.db"
+        )
+        
+        # Create config using from_args_with_defaults
+        config = CoverAgentConfig.from_args_with_defaults(args)
+        
+        # Verify None values were replaced with defaults
+        assert config.source_file_path == toml_defaults['source_file_path']
+        assert config.test_command == toml_defaults['test_command']
+        assert config.included_files == toml_defaults['included_files']
+        
+        # Verify other values came from args
+        assert config.test_file_path == "test.py"
+        assert config.code_coverage_report_path == "coverage.xml"
+        assert config.test_command_dir == "/project"
+        assert config.project_root == "/project"
+        assert config.test_file_output_path == "test_output.py"
+        assert config.coverage_type == "cobertura"
+        assert config.report_filepath == "report.html"
+        assert config.desired_coverage == 90
+        assert config.max_iterations == 10
+        assert config.max_run_time == 30
+        assert config.model == "gpt-4o"
+        assert config.api_base == "http://localhost:11434"
+        assert config.additional_instructions == ""
+        assert config.strict_coverage is False
+        assert config.run_tests_multiple_times == 1
+        assert config.run_each_test_separately is False
+        assert config.use_report_coverage_feature_flag is False
+        assert config.diff_coverage is False
+        assert config.branch == "main"
+        assert config.log_db_path == "test.db"


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactor CoverAgent to use CoverAgentConfig instead of argparse.Namespace
  - Replace all `args` usage with `config` object in CoverAgent
  - Update all internal references and logic accordingly

- Introduce CoverAgentConfig dataclass for configuration management
  - Add TOML-based default loading and merging with CLI args
  - Add methods for config creation from args and with defaults

- Update tests to use CoverAgentConfig and new initialization flow
  - Refactor all CoverAgent instantiations in tests to use config
  - Add comprehensive tests for CoverAgentConfig logic

- Update configuration.toml with new default and documentation structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CoverAgent.py</strong><dd><code>Refactor to use CoverAgentConfig instead of argparse.Namespace</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-dac868643df79ec6dfcf446359468a88ba6a6617bb8ffa0139757f0fbf5195b1">+57/-59</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Update main to use CoverAgentConfig for agent initialization</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-610f77abc2025129e317ec1f98b3bb375b790b2197ed3f635331cca0a06fd999">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config_schema.py</strong><dd><code>Add CoverAgentConfig dataclass with TOML/argparse merging logic</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-58e69011bb914eeb7caef2bfaa0fefbabc823a8fe6efbf5f1e08dcd7166cfed8">+146/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>configuration.toml</strong><dd><code>Add [default] section and document config options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-9dab1e24bace833ad70c0c2ec94e68e8649677c40badbc496d80bbe7aef520fb">+47/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_CoverAgent.py</strong><dd><code>Refactor tests to use CoverAgentConfig and new CoverAgent signature</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-5b29afeb89027737ac0cd2aaf08197f4aca8f4ef513b07b87a61ed3709aa190d">+24/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_config_schema.py</strong><dd><code>Add comprehensive tests for CoverAgentConfig logic and merging</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-494c6606c0c129c53edf721491f8ef54418eba18c06c46238b3dd8634cd24f86">+419/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_main.py</strong><dd><code>Update main tests for CoverAgentConfig and initialization logic</code></dd></td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/326/files#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>