### PR TITLE
Fix Jacoco parser test for unknown coverage types

### DIFF
--- a/tests/test_coverage_processor.py
+++ b/tests/test_coverage_processor.py
@@ -381,7 +381,7 @@ class TestCoverageProcessor:
         assert missed_lines == [2], "Expected line 2 to be missed for app.py"
         assert coverage_pct == 2 / 3, "Expected 66.67% coverage for app.py"
 
-    def test_parse_coverage_report_unsupported_type(self, mocker):
+    def test_parse_coverage_report_jacoco_unsupported_type(self, mocker):
         """
         Tests that parse_coverage_report_jacoco raises a ValueError for unsupported JaCoCo report formats.
         """


### PR DESCRIPTION
### **User description**
# PR Summary
The `test_parse_coverage_report_unsupported_type` test in `tests/test_CoverageProcessor.py` is duplicated. This PR resolves it so it won't be silently ignored.


___

### **PR Type**
Tests


___

### **Description**
- Renamed a test to clarify its purpose for JaCoCo parser.

- Improved test naming for unsupported coverage type handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_CoverageProcessor.py</strong><dd><code>Rename and clarify JaCoCo unsupported type test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_CoverageProcessor.py

<li>Renamed <code>test_parse_coverage_report_unsupported_type</code> to <br><code>test_parse_coverage_report_jacoco_unsupported_type</code>.<br> <li> Enhanced test clarity for unsupported JaCoCo report formats.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/qodo-cover/pull/328/files#diff-63a3b2f65d74764f35622a99cfbd946c878c01230cf19bb3befc67d2dbfec0c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>